### PR TITLE
update package.json to point to current wp package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pantheon-systems/gatsby-wordpress-starter",
+  "name": "@pantheon-systems/wordpress-kit",
   "version": "1.0.3",
   "private": true,
   "description": "Pantheon Decoupled Kit's Gatsby WordPress Starter",


### PR DESCRIPTION
edit `package.json` to point to current wp npm package: <https://www.npmjs.com/package/@pantheon-systems/wordpress-kit>

before:

```node
╰─❯ npm info
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/@pantheon-systems%2fgatsby-wordpress-starter - Not found
npm ERR! 404
npm ERR! 404  '@pantheon-systems/gatsby-wordpress-starter@latest' is not in this registry.
npm ERR! 404
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.
```

after:

```node
╰─❯ npm info
@pantheon-systems/wordpress-kit@1.0.2 | GPL-3.0-or-later | deps: 2 | versions: 2
Pantheon Decoupled Kit's WordPress Kit
https://github.com/pantheon-systems/decoupled-kit-js#readme

dist
.tarball: https://registry.npmjs.org/@pantheon-systems/wordpress-kit/-/wordpress-kit-1.0.2.tgz
.shasum: 2a57a5934e324fefc7d6f4df6e8cb774ff79390d
.integrity: sha512-ohXqzr7Cb7BtrzlCpLa4F4NDZ+X8Q28HHfTDynGpgJDPaoUy6c1Z4V4fjz/Cmif5ij6PJ8xIDqIMDuaLP8xd7A==
.unpackedSize: 41.8 kB

dependencies:
@apollo/client: ^3.5.10  isomorphic-fetch: ^3.0.0

maintainers:
- cobypear <pear.coby@gmail.com>
- backlineint <heybrianperry@gmail.com>
- pantheon-npm <vendor-npm@pantheon.io>

dist-tags:
latest: 1.0.2

published 2 weeks ago by cobypear <pear.coby@gmail.com>
```

